### PR TITLE
feat: 목표 이미지 기능 추가 및 receiveSticker API 개선

### DIFF
--- a/src/goals/dto/goal.input.ts
+++ b/src/goals/dto/goal.input.ts
@@ -8,6 +8,9 @@ export class GoalInput {
   @Field({ nullable: true })
   description?: string;
 
+  @Field({ nullable: true })
+  goalImage?: string;
+
   @Field()
   stickerCount: number;
 

--- a/src/goals/dto/receive-sticker.input.ts
+++ b/src/goals/dto/receive-sticker.input.ts
@@ -1,0 +1,13 @@
+import { Field, InputType } from '@nestjs/graphql';
+
+@InputType()
+export class ReceiveStickerInput {
+  @Field()
+  goalId: string;
+
+  @Field()
+  toUserId: string;
+
+  @Field()
+  stickerCount: number;
+}

--- a/src/goals/entities/goal.entity.ts
+++ b/src/goals/entities/goal.entity.ts
@@ -15,6 +15,9 @@ export class Goal {
   @Field({ nullable: true })
   description?: string;
 
+  @Field({ nullable: true })
+  goalImage?: string;
+
   @Field()
   stickerCount: number;
 

--- a/src/goals/goals.resolver.ts
+++ b/src/goals/goals.resolver.ts
@@ -4,6 +4,7 @@ import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { GoalInput } from './dto/goal.input';
 import { LeaveGoalInput } from './dto/leave-goal.input';
+import { ReceiveStickerInput } from './dto/receive-sticker.input';
 import { Goal } from './entities/goal.entity';
 import { GoalsService } from './goals.service';
 
@@ -21,6 +22,12 @@ export class GoalsResolver {
   @UseGuards(JwtAuthGuard)
   async getMyParticipatedGoals(@CurrentUser() userId: string) {
     return this.goalsService.findMyParticipatedGoals(userId);
+  }
+
+  @Query(() => [Goal], { name: 'getAllGoalsByUserId' })
+  @UseGuards(JwtAuthGuard)
+  async getAllGoalsByUserId(@Args('userId') targetUserId: string) {
+    return this.goalsService.findAllGoalsByUserId(targetUserId);
   }
 
   @Query(() => [Goal], { name: 'getFollowedUsersGoals' })
@@ -84,6 +91,20 @@ export class GoalsResolver {
     return this.goalsService.leaveGoal(
       input.goalId,
       input.participantId,
+      userId,
+    );
+  }
+
+  @Mutation(() => Goal, { name: 'receiveSticker' })
+  @UseGuards(JwtAuthGuard)
+  async receiveSticker(
+    @Args('input') input: ReceiveStickerInput,
+    @CurrentUser() userId: string,
+  ) {
+    return this.goalsService.receiveSticker(
+      input.goalId,
+      input.toUserId,
+      input.stickerCount,
       userId,
     );
   }

--- a/src/schema.gql
+++ b/src/schema.gql
@@ -64,6 +64,7 @@ type Goal {
   goalId: String!
   title: String!
   description: String
+  goalImage: String
   stickerCount: Float!
   mode: String
   visibility: String
@@ -107,6 +108,7 @@ type Query {
   getFollowRequests: [Follow!]!
   getGoals: [Goal!]!
   getMyParticipatedGoals: [Goal!]!
+  getAllGoalsByUserId(userId: String!): [Goal!]!
   getFollowedUsersGoals: [Goal!]!
   getGoalsByUserId(userId: String!): [Goal!]!
   getGoal(id: String!): Goal
@@ -131,6 +133,7 @@ type Mutation {
   updateGoal(id: String!, input: GoalInput!): Goal!
   deleteGoal(id: String!): Boolean!
   leaveGoal(input: LeaveGoalInput!): Goal!
+  receiveSticker(input: ReceiveStickerInput!): Goal!
   createGoalInvitation(input: CreateGoalInvitationInput!): GoalInvitation!
   createGoalJoinRequest(input: CreateGoalJoinRequestInput!): GoalInvitation!
   updateGoalInvitation(id: String!, input: UpdateGoalInvitationInput!): GoalInvitation!
@@ -172,6 +175,7 @@ input FollowInput {
 input GoalInput {
   title: String!
   description: String
+  goalImage: String
   stickerCount: Float!
   mode: String
   visibility: String
@@ -182,6 +186,12 @@ input GoalInput {
 input LeaveGoalInput {
   goalId: String!
   participantId: String!
+}
+
+input ReceiveStickerInput {
+  goalId: String!
+  toUserId: String!
+  stickerCount: Float!
 }
 
 input CreateGoalInvitationInput {

--- a/src/schemas/follow.schema.ts
+++ b/src/schemas/follow.schema.ts
@@ -7,6 +7,7 @@ export enum FollowStatus {
   PENDING = 'pending',
   APPROVED = 'approved',
   BLOCKED = 'blocked',
+  MUTUAL = 'mutual',
 }
 
 @Schema({ timestamps: true })

--- a/src/schemas/goal.schema.ts
+++ b/src/schemas/goal.schema.ts
@@ -65,6 +65,9 @@ export class Goal {
   @Prop()
   description?: string;
 
+  @Prop()
+  goalImage?: string;
+
   @Prop({ required: true })
   stickerCount: number;
 

--- a/src/upload/upload.module.ts
+++ b/src/upload/upload.module.ts
@@ -1,11 +1,16 @@
 import { Module, forwardRef } from '@nestjs/common';
 import { JwtModule } from '@nestjs/jwt';
+import { GoalsModule } from '../goals/goals.module';
 import { UsersModule } from '../users/users.module';
 import { AzureUploadService } from './azure-upload.service';
 import { UploadController } from './upload.controller';
 
 @Module({
-  imports: [forwardRef(() => UsersModule), JwtModule],
+  imports: [
+    forwardRef(() => UsersModule),
+    forwardRef(() => GoalsModule),
+    JwtModule,
+  ],
   providers: [AzureUploadService],
   controllers: [UploadController],
   exports: [AzureUploadService],

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -17,8 +17,8 @@ export class User {
   @Field({ nullable: true })
   profileImage?: string;
 
-  @Field({ nullable: true })
-  followStatus?: string;
+  @Field(() => String, { nullable: true })
+  followStatus?: string | null;
 
   // GraphQL에는 노출하지 않음
   password?: string;

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -103,9 +103,6 @@ export class UsersService {
         let followStatus: string | undefined = undefined;
         if (currentUserId) {
           try {
-            console.log(
-              `Checking follow status: ${currentUserId} -> ${user.userId}`,
-            );
             const followStatusResult =
               await this.followsService.checkFollowStatus(
                 currentUserId,
@@ -114,11 +111,12 @@ export class UsersService {
             followStatus = followStatusResult.followStatus;
           } catch (error) {
             console.error('Error checking follow status:', error);
+            followStatus = undefined;
           }
         }
         return {
           ...user,
-          followStatus,
+          followStatus: followStatus || null,
         };
       }),
     );


### PR DESCRIPTION
### 주요 변경사항:

#### 🎯 목표 이미지 기능 추가
- `goalImage` 필드를 목표 스키마, 엔티티, DTO에 추가
- `createGoal`과 `updateGoal`에서 `goalImage` 함께 등록/수정 가능
- REST API `POST /upload/goal-image` 추가 (Azure Blob Storage 연동)
- `UploadModule`에 `GoalsModule` 의존성 추가

#### �� receiveSticker API 개선
- `ReceiveStickerInput` DTO 필드 변경: `participantId` → `toUserId`
- `stickerCount` 필드 추가로 지정 개수만큼 스티커 증가
- `GoalsService.receiveSticker` 메서드 매개변수 수정
- `GoalsResolver.receiveSticker` 뮤테이션 업데이트

#### 🧹 코드 정리
- 테스트용 `console.log` 디버깅 로그 모두 제거
- `updateGoalImage` 별도 API 제거 (통합된 `updateGoal` 사용)
- `UpdateGoalImageInput` DTO 제거